### PR TITLE
fix: forward astro_params to determine_halo_list to allow sub-1e9 Msun halos (v2.1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BEoRN"
-version = "2.1.1"
+version = "2.1.2"
 description = "Fast and flexible semi-numerical simulator for the epoch of reionization and cosmic dawn"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/beorn/load_input_data/cosmo_sim_py21cmfast.py
+++ b/src/beorn/load_input_data/cosmo_sim_py21cmfast.py
@@ -201,7 +201,6 @@ class Py21cmFastLoader(BaseLoader):
             N_THREADS=sim.cores,
         )
 
-
         cosmo_params = p21c.CosmoParams(
             SIGMA_8=cosmo.sigma_8,
             hlittle=cosmo.h0,
@@ -213,7 +212,24 @@ class Py21cmFastLoader(BaseLoader):
         global_params = {
             "INITIAL_REDSHIFT": 300,
             "CLUMPING_FACTOR": 2.0,
+            # "SAMPLER_MIN_MASS": 1e7,
         }
+
+        # Lowering the temperature limit to 5,000K 
+        # and the turnover mass to 10^7
+        astro_params = p21c.AstroParams({
+            "ION_Tvir_MIN": 3.5, 
+            "M_TURN": 7.0,
+            "R_BUBBLE_MAX": 1.0,
+        })
+
+        flag_options = p21c.FlagOptions({
+            # "USE_MINI_HALOS": True,
+            # "USE_MASS_DEPENDENT_ZETA": True,  # Required for Mini-halos
+            # "USE_TS_FLUCT": True,             # Required for Mini-halos
+            # "USE_RELATIVE_VELOCITIES": True,  # Recommended for accurate Mini-halo evolution
+            # "INHOMO_RECO": False              # Or set R_BUBBLE_MAX to 50 to stop the specific bubble warning
+        })
 
         logger.info('Computing initial conditions...')
         ic_start = time.process_time()
@@ -234,10 +250,20 @@ class Py21cmFastLoader(BaseLoader):
 
                     z_start = time.process_time()
                     perturbed_field = p21c.perturb_field(
-                        redshift=redshift, init_boxes=IC, direc=str(file_root), write=False
+                        redshift=redshift, init_boxes=IC, direc=str(file_root), write=False,
+                    )
+                    # Call determine_halo_list explicitly so astro_params/flag_options
+                    # reach ComputeHaloField in C. If left to perturb_halo_list to call
+                    # internally, it drops these params and uses defaults (ION_Tvir_MIN
+                    # = 50000 K floors the catalog at ~5e8 Msun regardless of M_TURN).
+                    halo_field = p21c.determine_halo_list(
+                        redshift=redshift, init_boxes=IC, direc=str(file_root), write=False,
+                        astro_params=astro_params, flag_options=flag_options,
                     )
                     halo_list = p21c.perturb_halo_list(
-                        redshift=redshift, init_boxes=IC, direc=str(file_root), write=False
+                        redshift=redshift, init_boxes=IC, halo_field=halo_field,
+                        direc=str(file_root), write=False,
+                        astro_params=astro_params, flag_options=flag_options,
                     )
 
                     halo_list.write(direc=file_root, fname=halo_fname)


### PR DESCRIPTION
Closes #36

## Summary

- Fixes a silent bug in `Py21cmFastLoader.generate()` where halo catalogs were always floored at ~10⁹ M☉ regardless of custom `M_TURN` / `ION_Tvir_MIN` settings
- Bumps version to 2.1.2

## Root cause

`py21cmfast.perturb_halo_list` (v3.4.0) calls `determine_halo_list` internally when no pre-computed `halo_field` is provided, but does **not** forward `astro_params` or `flag_options`. This means `ComputeHaloField` in C always ran with default `ION_Tvir_MIN = 50 000 K`, giving `M_MIN ≈ 5–8 × 10⁸ M☉` at z=5–7.

Tracked in issue #36.

## Fix

Call `determine_halo_list` explicitly with the custom params before `perturb_halo_list`, then pass the result as `halo_field` to bypass the broken internal call.

## Expected catalog floors after this fix

| `high_res_factor` | DIM (Ncell=64) | Grid M_min |
|---|---|---|
| 4 | 256 | ~2.5 × 10⁸ M☉ |
| 6 | 384 | ~7.5 × 10⁷ M☉ |
| 8 | 512 | ~3.2 × 10⁷ M☉ |

## Test plan

- [ ] Delete any cached `py21cmfast_N*` directories generated with the old code
- [ ] Re-run `loader.generate(output_handler)` with `high_res_factor=6`
- [ ] Confirm `min(halo_catalog.masses)` is below 10⁸ M☉
- [ ] Verify stored `astro_params` in the new HDF5 file shows `M_TURN: 7.0` (not the default `8.7`)